### PR TITLE
netlog: fix some minor grammar issues in the comments and documentation

### DIFF
--- a/biglog/README.md
+++ b/biglog/README.md
@@ -1,8 +1,8 @@
 # BigLog
 
-BigLog is a high level abstraction on top os.File designed to store large amounts of data. BigLog is NetLog's core component, which can be embedded in any application.
+BigLog is a high level abstraction on top of os.File designed to store large amounts of data. BigLog is NetLog's core component, which can be embedded in any application.
 
-In a log-based queue, logs must be append-only. But most people eventually need to delete data, so instead of a single file we have several "segments". Every segment is just a data file with blob of bytes written to it and a companion index file. Indexes are preallocated in a fixed size every time a segment is created and memory-mapped. Each entry in the index has the format.
+In a log-based queue, logs must be append-only. But most people eventually need to delete data, so instead of a single file we have several "segments". Every segment is just a data file with blob of bytes written to it and a companion index file. Indexes are preallocated in a fixed size every time a segment is created and memory-mapped. Each entry in the index has the format:
 
 ### Index entry format
 
@@ -14,7 +14,7 @@ In a log-based queue, logs must be append-only. But most people eventually need 
 +---------------------------------------------------------------+
 ```
 
-Every segment has a base offset, and the index stores the relative offset to that base, with the first offset being always 1. The index can be sparse. The last element of the index is always the NEXT offset to be written, who's timestamp is not set.
+Every segment has a base offset, and the index stores the relative offset to that base, with the first offset being always 1. The index can be sparse. The last element of the index is always the NEXT offset to be written, whose timestamp is not set.
 
 ### Index example
 
@@ -30,9 +30,9 @@ Every segment has a base offset, and the index stores the relative offset to tha
 +-----------------------------------+     (size of the data file)
 ```
 
-The segment with the highest base offset is the "hot" segment, the only one who gets writes under the hood via Write() [io.Writer interface] for a single offset or WriteN() for N offsets. You can create a new hot segment calling Split(), and discard the oldest one calling Trim().
+The segment with the highest base offset is the "hot" segment, the only one which gets writes under the hood via Write() [io.Writer interface] for a single offset or WriteN() for N offsets. You can create a new hot segment calling Split(), and discard the oldest one calling Trim().
 
-There are 2 reading primitives, a Reader [io.Reader] which reads over the data files returning byte blobs, and an Index Reader which reads index files retuning entries. Both are initialized (multiple instances allowed) and operate separately.
+There are 2 reading primitives, a Reader [io.Reader] which reads over the data files returning byte blobs, and an Index Reader which reads index files returning entries. Both are initialized (multiple instances allowed) and operate separately.
 
 ```
                      +------------------+
@@ -49,6 +49,6 @@ There are 2 reading primitives, a Reader [io.Reader] which reads over the data f
                              +------------------+
 ```
 
-Readers will transparently jump through segments until their buffer is full or EOF is reached, they can be instantiated to start in any give offset with an specific entry in the index, if an embedded offset it requested the reader will start in the previous known offset position.
+Readers will transparently jump through segments until their buffer is full or EOF is reached, they can be instantiated to start at any give offset with a specific entry in the index, if an embedded offset is requested the reader will start in the previous known offset position.
 
 Based on these 2 readers, BigLog provides another 2 higher abstractions, Scanner and Streamer. [See the godocs](https://godoc.org/github.com/ninibe/netlog/biglog).

--- a/biglog/biglog.go
+++ b/biglog/biglog.go
@@ -254,7 +254,7 @@ func (bl *BigLog) Latest() int64 {
 func (bl *BigLog) latest() int64 {
 	hotSeg := bl.hotSeg.Load().(*segment)
 
-	// If there only one segment and it's empty
+	// If there is only one segment and it's empty
 	if len(bl.segs) == 1 && hotSeg.NRO == 1 {
 		return -1 // no data
 	}
@@ -361,7 +361,7 @@ func (bl *BigLog) Trim() (err error) {
 	return nil
 }
 
-// Close frees the all resources, rendering the BigLog unusable without
+// Close frees all resources, rendering the BigLog unusable without
 // touching the data persisted on disk.
 func (bl *BigLog) Close() error {
 	bl.mu.Lock()  // lock writes

--- a/biglog/index_reader.go
+++ b/biglog/index_reader.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-// ErrInvalidIndexReader returned on read with nil pointers
+// ErrInvalidIndexReader is returned on read with nil pointers
 var ErrInvalidIndexReader = errors.New("biglog: invalid reader - use NewIndexReader")
 
 // ErrNeedMoreBytes is returned by in the index reader when a single entry does not fit the requested byte limit
@@ -59,7 +59,7 @@ type Entry struct {
 	Size int
 }
 
-// NewIndexReader returns a IndexReader that will start reading from a given offset
+// NewIndexReader returns an IndexReader that will start reading from a given offset
 func NewIndexReader(bl *BigLog, from int64) (r *IndexReader, ret int64, err error) {
 	seg, RO, err := bl.locateOffset(from)
 	if err != nil {
@@ -85,7 +85,7 @@ func NewIndexReader(bl *BigLog, from int64) (r *IndexReader, ret int64, err erro
 }
 
 // ReadEntries reads n entries from the index. This method is useful when scanning single entries one by one
-// for streaming use is ReadSection is recommended
+// for streaming use, ReadSection is recommended
 func (r *IndexReader) ReadEntries(n int) (entries []*Entry, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -119,9 +119,9 @@ func (r *IndexReader) ReadEntries(n int) (entries []*Entry, err error) {
 	return entries, err
 }
 
-// ReadSection reads section of the index that contains a maximum of offsets or bytes
+// ReadSection reads the section of the index that contains a maximum of offsets or bytes
 // it's lower precision than ReadEntries but better suited for streaming since it does not need to allocate
-// a Entry struct for every entry read in the index.
+// an Entry struct for every entry read in the index.
 func (r *IndexReader) ReadSection(maxOffsets, maxBytes int64) (is *IndexSection, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/biglog/reader.go
+++ b/biglog/reader.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 )
 
-// ErrInvalidReader returned on read with nil pointers
+// ErrInvalidReader is returned on read with nil pointers
 var ErrInvalidReader = errors.New("biglog: invalid reader - use NewReader")
 
 // Reader keeps the state among separate concurrent reads
@@ -51,7 +51,7 @@ func NewReader(bl *BigLog, from int64) (r *Reader, ret int64, err error) {
 	return r, ret, err
 }
 
-// Read bytes from the big log, offset is auto-incremented in every read
+// Read reads bytes from the big log, offset is auto-incremented in every read
 func (r *Reader) Read(b []byte) (n int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/biglog/scanner.go
+++ b/biglog/scanner.go
@@ -11,7 +11,7 @@ import (
 
 // Scanner facilitates reading a BigLog's content one index entry at a time.
 // Instantiate always via NewScanner. A scanner is NOT thread-safe, to use
-// is concurrently your application must protect it with a mutex.
+// it concurrently your application must protect it with a mutex.
 type Scanner struct {
 	token      []byte
 	buf        []byte
@@ -30,7 +30,7 @@ type ScannerOption func(*Scanner)
 
 // UseBuffer option facilitates to bring your own buffer to the scanner,
 // if the buffer is not big enough for an entry it will be replaced
-// with a bigger one. You can prevent this behaviours setting
+// with a bigger one. You can prevent this behaviours by setting
 // MaxBufferSize to len(buf).
 func UseBuffer(buf []byte) ScannerOption {
 	return func(s *Scanner) {
@@ -39,7 +39,7 @@ func UseBuffer(buf []byte) ScannerOption {
 }
 
 // MaxBufferSize option defines the maximum buffer size that the
-// scanner is allowed to use. If an entry is lager than the max buffer
+// scanner is allowed to use. If an entry is larger than the max buffer
 // scanning will fail with error ErrTooLong. Default size 0 means no limit.
 func MaxBufferSize(size int) ScannerOption {
 	return func(s *Scanner) {
@@ -50,7 +50,7 @@ func MaxBufferSize(size int) ScannerOption {
 // ErrEntryTooLong is returned when the entry is too big to fit in the allowed buffer size.
 var ErrEntryTooLong = errors.New("biglog.Scanner: entry too long")
 
-// ErrInvalidScanner returned when using an uninitialized scanner.
+// ErrInvalidScanner is returned when using an uninitialized scanner.
 var ErrInvalidScanner = errors.New("biglog: invalid reader - use NewScanner")
 
 // NewScanner returns a new Scanner starting at `from` offset.
@@ -210,7 +210,7 @@ func (s *Scanner) Offset() int64 {
 	return s.entry.Offset
 }
 
-// ODelta returns the numbers of offsets included in the scanned entry.
+// ODelta returns the number of offsets included in the scanned entry.
 func (s *Scanner) ODelta() int {
 	if s.entry == nil {
 		return 0

--- a/biglog/streamer.go
+++ b/biglog/streamer.go
@@ -81,7 +81,7 @@ func NewStreamer(bl *BigLog, from int64) (s *Streamer, err error) {
 }
 
 // Get given a maximum number of offsets and a maximum number of bytes, returns a StreamDelta
-// for the biggest chunk of that satisfied the limits until EOF. If the next entry is too big
+// for the biggest chunk that satisfied the limits until EOF. If the next entry is too big
 // for either limit, either ErrNeedMoreOffsets or ErrNeedMoreBytes is returned.
 // IMPORTANT: The StreamDelta must be "Put" back before a new one can issued.
 func (st *Streamer) Get(maxOffsets, maxBytes int64) (delta *StreamDelta, err error) {
@@ -105,7 +105,7 @@ func (st *Streamer) Get(maxOffsets, maxBytes int64) (delta *StreamDelta, err err
 	return delta, err
 }
 
-// Put must be called once and StreamDelta has been successfully read
+// Put must be called once StreamDelta has been successfully read
 // so the reader can advance and a new StreamDelta can be issued.
 func (st *Streamer) Put(delta *StreamDelta) (err error) {
 	defer st.mu.Unlock()

--- a/topic.go
+++ b/topic.go
@@ -153,7 +153,7 @@ type ioFlusher interface {
 }
 
 // FlushBuffered flushes all buffered messages into the BigLog.
-// Notice that the BigLog might have a buffer on it's own that this
+// Notice that the BigLog might have a buffer on its own that this
 // function does not flush, so calling this does not mean the data
 // has been stored on disk.
 func (t *Topic) FlushBuffered() error {

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -30,7 +30,7 @@ type TopicScanner interface {
 }
 
 // NewTopicScanner returns a new topic scanner ready to scan starting at offset `from`,
-// if persist is true, the scanner and it's last position will survive across server restarts
+// if persist is true, the scanner and its last position will survive across server restarts
 func NewTopicScanner(t *Topic, ID string, from int64, persist bool) (TopicScanner, error) {
 	bts, err := newBLTopicScanner(t, ID, from)
 	if err != nil {


### PR DESCRIPTION
While reading the code and its documentation I stumbled upon some minor grammar issues. So I just fixed the ones I came across. I also tried to improve the consistency of some comments.

Thanks for your work and the great documentation. It helped a lot.